### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Prefs.php
+++ b/lib/Horde/Prefs.php
@@ -527,21 +527,25 @@ class Horde_Prefs implements ArrayAccess
 
     /* ArrayAccess methods. */
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return !is_null($this->getValue($offset));
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getValue($offset);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->setValue($offset, $value);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->remove($offset);

--- a/lib/Horde/Prefs/Identity.php
+++ b/lib/Horde/Prefs/Identity.php
@@ -98,11 +98,13 @@ implements ArrayAccess, Countable, IteratorAggregate
         $this->_prefs = $params['prefs'];
         $this->_user = $params['user'];
 
-        if (!($this->_identities = @unserialize($this->_prefs->getValue($this->_prefnames['identities'])))) {
-            $this->_identities = $this->_prefs->getDefault($this->_prefnames['identities']);
-        }
+        foreach ($this->_prefs as $val) {
+            if (!($this->_identities = @unserialize($val->getValue($this->_prefnames['identities'])))) {
+                $this->_identities = $val->getDefault($this->_prefnames['identities']);
+            }
 
-        $this->setDefault($this->_prefs->getValue($this->_prefnames['default_identity']));
+            $this->setDefault($val->getValue($this->_prefnames['default_identity']));
+        }
     }
 
     /**
@@ -415,7 +417,7 @@ implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @since 2.7.0
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->_identities[$offset]);
     }
@@ -423,7 +425,7 @@ implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @since 2.7.0
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->get($offset);
     }
@@ -431,7 +433,7 @@ implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @since 2.7.0
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         // $value is ignored.
         $this->set($offset);
@@ -440,7 +442,7 @@ implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @since 2.7.0
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->delete($offset);
     }
@@ -450,7 +452,7 @@ implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @since 2.7.0
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_identities);
     }
@@ -460,7 +462,7 @@ implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @since 2.7.0
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_identities);
     }

--- a/lib/Horde/Prefs/Scope.php
+++ b/lib/Horde/Prefs/Scope.php
@@ -276,6 +276,7 @@ class Horde_Prefs_Scope implements Iterator, Serializable
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_fromInternal($this->key());
@@ -283,6 +284,7 @@ class Horde_Prefs_Scope implements Iterator, Serializable
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->_prefs);
@@ -290,6 +292,7 @@ class Horde_Prefs_Scope implements Iterator, Serializable
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         return next($this->_prefs);
@@ -297,6 +300,7 @@ class Horde_Prefs_Scope implements Iterator, Serializable
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->_prefs);
@@ -304,6 +308,7 @@ class Horde_Prefs_Scope implements Iterator, Serializable
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return !is_null(key($this->_prefs));

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Prefs/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Prefs/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Pref Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Prefs/Unit/IdentityTest.php
+++ b/test/Horde/Prefs/Unit/IdentityTest.php
@@ -21,13 +21,13 @@
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   Prefs
  */
-class Horde_Prefs_Unit_IdentityTest extends PHPUnit_Framework_TestCase
+class Horde_Prefs_Unit_IdentityTest extends Horde_Test_Case
 {
     private $identity;
 
     /**
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->identity = new Horde_Prefs_Identity(array(
             'prefs' => new Horde_Prefs(
@@ -53,7 +53,7 @@ class Horde_Prefs_Unit_IdentityTest extends PHPUnit_Framework_TestCase
     {
         $this->identity->add(array());
 
-        $this->assertInternalType('array', $this->identity->get(0));
+        $this->assertIsArray($this->identity->get(0));
         $this->assertNull($this->identity->get(1));
     }
 
@@ -87,7 +87,7 @@ class Horde_Prefs_Unit_IdentityTest extends PHPUnit_Framework_TestCase
     {
         $this->identity->add(array());
 
-        $this->assertInternalType('array', $this->identity[0]);
+        $this->assertIsArray($this->identity[0]);
         $this->assertNull($this->identity[1]);
     }
 
@@ -97,7 +97,7 @@ class Horde_Prefs_Unit_IdentityTest extends PHPUnit_Framework_TestCase
     {
         $this->identity->add(array());
 
-        $this->assertInternalType('array', $this->identity[0]);
+        $this->assertIsArray($this->identity[0]);
 
         unset($this->identity[0]);
 

--- a/test/Horde/Prefs/Unit/Storage/FileTest.php
+++ b/test/Horde/Prefs/Unit/Storage/FileTest.php
@@ -23,26 +23,23 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Prefs_Unit_Storage_FileTest extends PHPUnit_Framework_TestCase
+class Horde_Prefs_Unit_Storage_FileTest extends Horde_Test_Case
 {
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testMissingDirectory()
     {
+        $this->expectException('InvalidArgumentException');
         $b = new Horde_Prefs_Storage_File('nobody');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidDirectory()
     {
+        $this->expectException('InvalidArgumentException');
         $b = new Horde_Prefs_Storage_File('nobody', array('directory' => __DIR__ . '/DOES_NOT_EXIST'));
     }
 
     public function testConstruction()
     {
+        $this->expectNotToPerformAssertions();
         $b = new Horde_Prefs_Storage_File('nobody', array('directory' => Horde_Util::createTempDir()));
     }
 }

--- a/test/Horde/Prefs/Unit/Storage/KolabImapLogTest.php
+++ b/test/Horde/Prefs/Unit/Storage/KolabImapLogTest.php
@@ -25,7 +25,7 @@
  */
 class Horde_Prefs_Unit_Storage_KolabImapLogTest extends Horde_Test_Log
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('Horde_Kolab_Storage_Factory')) {
             $this->markTestSkipped('Horde_Kolab_Storage package is missing');

--- a/test/Horde/Prefs/Unit/Storage/KolabImapTest.php
+++ b/test/Horde/Prefs/Unit/Storage/KolabImapTest.php
@@ -19,9 +19,9 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Prefs_Unit_Storage_KolabImapTest extends PHPUnit_Framework_TestCase
+class Horde_Prefs_Unit_Storage_KolabImapTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('Horde_Kolab_Storage_Factory')) {
             $this->markTestSkipped('Horde_Kolab_Storage package is missing');
@@ -29,16 +29,15 @@ class Horde_Prefs_Unit_Storage_KolabImapTest extends PHPUnit_Framework_TestCase
         $_SESSION = array();
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testMissingStorage()
     {
+        $this->expectException('InvalidArgumentException');
         $b = new Horde_Prefs_Storage_KolabImap('nobody');
     }
 
     public function testConstruction()
     {
+        $this->expectNotToPerformAssertions();
         $b = new Horde_Prefs_Storage_KolabImap(
             'nobody', array('kolab' => $this->_createDefaultStorage())
         );
@@ -161,7 +160,7 @@ class Horde_Prefs_Unit_Storage_KolabImapTest extends PHPUnit_Framework_TestCase
                     'data' => array('queryset' => 'horde'),
                 ),
                 'cache'  => new Horde_Cache(new Horde_Cache_Storage_Mock()),
-                'logger' => $this->getMock('Horde_Log_Logger'),
+                'logger' => $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             )
         );
         return $factory->create();

--- a/test/Horde/Prefs/Unit/Storage/Sql/Base.php
+++ b/test/Horde/Prefs/Unit/Storage/Sql/Base.php
@@ -55,7 +55,7 @@ class Horde_Prefs_Test_Sql_Base extends Horde_Test_Case
         );
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $logger = new Horde_Log_Logger(new Horde_Log_Handler_Cli());
         //self::$db->setLogger($logger);
@@ -81,7 +81,7 @@ class Horde_Prefs_Test_Sql_Base extends Horde_Test_Case
         self::$prefs = new Horde_Prefs_Storage_Sql('joe', array('db' => self::$db));
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$prefs = null;
         if (self::$db) {
@@ -97,7 +97,7 @@ class Horde_Prefs_Test_Sql_Base extends Horde_Test_Case
         }
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!self::$db) {
             $this->markTestSkipped(self::$reason);

--- a/test/Horde/Prefs/Unit/Storage/Sql/MysqlTest.php
+++ b/test/Horde/Prefs/Unit/Storage/Sql/MysqlTest.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/Base.php';
  */
 class Horde_Prefs_Unit_Storage_Sql_MysqlTest extends Horde_Prefs_Test_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('mysql')) {
             self::$reason = 'No mysql extension';

--- a/test/Horde/Prefs/Unit/Storage/Sql/MysqliTest.php
+++ b/test/Horde/Prefs/Unit/Storage/Sql/MysqliTest.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/Base.php';
  */
 class Horde_Prefs_Unit_Storage_Sql_MysqliTest extends Horde_Prefs_Test_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('mysqli')) {
             self::$reason = 'No mysqli extension';

--- a/test/Horde/Prefs/Unit/Storage/Sql/Oci8Test.php
+++ b/test/Horde/Prefs/Unit/Storage/Sql/Oci8Test.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/Base.php';
  */
 class Horde_Prefs_Unit_Storage_Sql_Oci8Test extends Horde_Prefs_Test_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('oci8')) {
             self::$reason = 'No oci8 extension';

--- a/test/Horde/Prefs/Unit/Storage/Sql/Pdo/MysqlTest.php
+++ b/test/Horde/Prefs/Unit/Storage/Sql/Pdo/MysqlTest.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/../Base.php';
  */
 class Horde_Prefs_Unit_Storage_Sql_Pdo_MysqlTest extends Horde_Prefs_Test_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('pdo') ||
             !in_array('mysql', PDO::getAvailableDrivers())) {

--- a/test/Horde/Prefs/Unit/Storage/Sql/Pdo/PgsqlTest.php
+++ b/test/Horde/Prefs/Unit/Storage/Sql/Pdo/PgsqlTest.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/../Base.php';
  */
 class Horde_Prefs_Unit_Storage_Sql_Pdo_PgsqlTest extends Horde_Prefs_Test_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('pdo') ||
             !in_array('pgsql', PDO::getAvailableDrivers())) {

--- a/test/Horde/Prefs/Unit/Storage/Sql/Pdo/SqliteTest.php
+++ b/test/Horde/Prefs/Unit/Storage/Sql/Pdo/SqliteTest.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/../Base.php';
  */
 class Horde_Prefs_Unit_Storage_Sql_Pdo_SqliteTest extends Horde_Prefs_Test_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $factory_db = new Horde_Test_Factory_Db();
 


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-prefs/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix autopkgtest failure due to php8.1 changes https://salsa.debian.org/horde-team/php-horde-prefs/-/blob/debian-sid/debian/patches/2010_phpunit-8.1.patch
- Debian changes: Fix some more warnings. Allow-stderr https://salsa.debian.org/horde-team/php-horde-prefs/-/blob/debian-sid/debian/patches/2020_phpunit-8.x.patch
