### PR TITLE
fix(security): restrict unserialize allowed_classes (ZDI-20-1051)

### DIFF
--- a/lib/Horde/Prefs/Cache/HordeCache.php
+++ b/lib/Horde/Prefs/Cache/HordeCache.php
@@ -50,7 +50,8 @@ class Horde_Prefs_Cache_HordeCache extends Horde_Prefs_Cache_Base
     public function get($scope)
     {
         return @unserialize(
-            $this->_params['cache']->get($this->_cacheId($scope), 0)
+            $this->_params['cache']->get($this->_cacheId($scope), 0),
+            ['allowed_classes' => ['Horde_Prefs_Scope']]
         );
     }
 

--- a/lib/Horde/Prefs/Identity.php
+++ b/lib/Horde/Prefs/Identity.php
@@ -107,7 +107,7 @@ class Horde_Prefs_Identity implements ArrayAccess, Countable, IteratorAggregate
 
         $raw = $this->_prefs->getValue($this->_prefnames['identities']);
         if (is_string($raw) && strlen($raw)) {
-            $result = @unserialize($raw);
+            $result = @unserialize($raw, ['allowed_classes' => false]);
             $this->_identities = is_array($result) ? $result : [];
         } else {
             $this->_identities = [];

--- a/lib/Horde/Prefs/Storage/File.php
+++ b/lib/Horde/Prefs/Storage/File.php
@@ -104,7 +104,7 @@ class Horde_Prefs_Storage_File extends Horde_Prefs_Storage_Base
                 return false;
             }
 
-            $this->_fileCache = @unserialize(file_get_contents($this->_fullpath));
+            $this->_fileCache = @unserialize(file_get_contents($this->_fullpath), ['allowed_classes' => false]);
 
             // Check version number. We can call format transformations hooks
             // in the future.


### PR DESCRIPTION
## Summary

Follow-up to horde/imp#7

- Cache (HordeCache): allow only `Horde_Prefs_Scope`
- Identity: restricted to data-only with no class support
- File storage: restricted to data-only with no class support