### PR TITLE
fix(prefs): cast values to string before binary SQL storage

### DIFF
--- a/lib/Horde/Prefs/Storage/Sql.php
+++ b/lib/Horde/Prefs/Storage/Sql.php
@@ -126,7 +126,7 @@ class Horde_Prefs_Storage_Sql extends Horde_Prefs_Storage_Base
                 }
 
                 /* Driver has no support for storing locked status. */
-                $value = Horde_String::convertCharset($value, 'UTF-8', $charset);
+                $value = strval(Horde_String::convertCharset($value, 'UTF-8', $charset));
                 $value = new Horde_Db_Value_Binary($value);
 
                 if (empty($check)) {

--- a/lib/Horde/Prefs/Storage/Sql.php
+++ b/lib/Horde/Prefs/Storage/Sql.php
@@ -13,6 +13,8 @@
  * @package  Prefs
  */
 
+use Horde\Util\HordeString;
+
 /**
  * Preferences storage implementation for a SQL database.
  *
@@ -125,8 +127,12 @@ class Horde_Prefs_Storage_Sql extends Horde_Prefs_Storage_Base
                     throw new Horde_Prefs_Exception($e);
                 }
 
-                /* Driver has no support for storing locked status. */
-                $value = strval(Horde_String::convertCharset($value, 'UTF-8', $charset));
+                /* Driver has no support for storing locked status.
+                 * strval() before charset conversion so non-string scalars
+                 * (e.g. integer 0/1 from checkbox prefs) are normalized
+                 * before reaching the PDO blob layer, which serializes
+                 * string data only. */
+                $value = HordeString::convertCharset(strval($value), 'UTF-8', $charset);
                 $value = new Horde_Db_Value_Binary($value);
 
                 if (empty($check)) {


### PR DESCRIPTION
## Summary

- Cast preference values to strings with `strval()` before storing them as `Horde_Db_Value_Binary` in `horde_prefs`
- Fixes checkbox and number preferences (e.g. IMP `use_trash`) that appeared to save successfully but reloaded with empty values
- Root cause: integer scalars passed to the PDO blob layer were treated as non-strings and persisted as empty binary data

## Problem

The preferences UI stores checkbox values via `intval()`, producing integer `0`/`1`. `Horde_Prefs_Storage_Sql` passed those values directly to `Horde_Db_Value_Binary`. The PDO blob helper only serializes string data; integers were written as empty blobs.

Observed symptom in IMP:

1. User enables “Move deleted messages to Trash”
2. Horde shows “Your preferences have been updated.”
3. After reload, the checkbox is unchecked and trash behavior is unchanged
4. Database row exists but `pref_value` is empty

## Solution

Normalize the value to a string before charset conversion and binary wrapping:

```php
$value = strval(Horde_String::convertCharset($value, 'UTF-8', $charset));
$value = new Horde_Db_Value_Binary($value);
```

Preference storage is string-based by design; this keeps SQL storage aligned with that contract regardless of upstream scalar types.

## Test plan

- [ ] Save IMP preference `use_trash` as enabled for a test user
- [ ] Confirm `horde_prefs.pref_value` contains `1` (not an empty blob)
- [ ] Reload preferences UI and verify the checkbox stays checked
- [ ] Verify trash mailbox selection appears after `use_trash` is enabled
- [ ] Save a checkbox preference as disabled and confirm `0` is stored correctly
- [ ] Regression: save a text/textarea preference and confirm unchanged behavior
