### PR TITLE
fix(prefs): resolve autoloader via composer proxy globals

### DIFF
--- a/bin/horde-prefs
+++ b/bin/horde-prefs
@@ -76,11 +76,13 @@ use \Composer\InstalledVersions;
 
 // Autoloader search run in composer setups
 $autoloaders = [
+    $GLOBALS['_composer_autoload_path'] ?? null,
     __DIR__ . '/../vendor/autoload.php', // prefs is the root package
     __DIR__ . '/../../../../vendor/autoload.php', // prefs is in the vendor dir
     // handle "git developer install" and pear cases
     'Horde/Autoloader/Default.php'
 ];
+$autoloaders = array_filter($autoloaders);
 
 foreach ($autoloaders as $autoloader) {
     if (file_exists($autoloader)) {


### PR DESCRIPTION
bin/horde-prefs computes the path to vendor/autoload.php using a fixed relative 
depth from DIR. When horde/prefs is installed as a symlink to a git checkout
(composer "path" repository, as used in git developer installs), PHP resolves
DIR through the symlink target, breaking the fixed-depth assumption and causing
the script to fail with "Neither Composer nor PEAR Horde_Autoloader_Default
available" even though a valid autoloader exists.

The composer-generated bin proxy already computes the correct path via 
$GLOBALS['_composer_autoload_path'] before including this script. Use it when
available, falling back to the existing depth-based paths unchanged for PEAR
installs or direct invocation outside the proxy.

Reproduced and verified fixed on a git developer install (horde/prefs
symlinked via path repository). I don't have a standard composer
(non-symlinked) install to test against. The fixed-depth path this
patch falls back to is unchanged from the existing code, and by
inspection it matches the directory structure composer produces for
a standard install (vendor/horde/prefs/bin, 4 levels from project
root) — but I haven't actually run this against one. Would
appreciate a confirmation from someone with a standard install.

Searched the entire /var/www/horde-git tree for other bin scripts sharing this 
same bootstrap pattern (grep -rl 'handle "git developer install"'). One other
file matched — horde/components/bin/horde-components — but it uses a different
path structure (different depths, plus an additional config/autoload.php entry)
and serves a different purpose (build tool for the .phar, with a separate
GitHub webhook mode). Out of scope for this fix.
